### PR TITLE
teste

### DIFF
--- a/librio/lib/src/presentation/home/widgets/book_card.dart
+++ b/librio/lib/src/presentation/home/widgets/book_card.dart
@@ -28,7 +28,7 @@ class BookCard extends StatelessWidget {
           clipBehavior: Clip.antiAlias,
           elevation: 2,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16.0),
+            borderRadius: BorderRadius.circular(16),
           ),
           child: book.imageUrl.isNotEmpty
               ? Image.network(


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use integer literal for border radius.circular instead of a floating-point value